### PR TITLE
pretty print methods should return the string, not just print

### DIFF
--- a/treys/card.py
+++ b/treys/card.py
@@ -196,7 +196,7 @@ class Card:
         """
         Expects a single integer as input
         """
-        print(Card.int_to_pretty_str(card_int))
+        return Card.int_to_pretty_str(card_int)
 
     @staticmethod
     def print_pretty_cards(card_ints):
@@ -211,4 +211,4 @@ class Card:
             else:
                 output += str(Card.int_to_pretty_str(c)) + " "
     
-        print(output)
+        return output


### PR DESCRIPTION
deck's __str__ method calls print_pretty_card, but because it prints a card representation instead of returning it, that causes a TypeError (see commit comment).