### PR TITLE
Fix deck of 104 cards

### DIFF
--- a/treys/card.py
+++ b/treys/card.py
@@ -29,6 +29,7 @@ class Card:
 
     # the basics
     STR_RANKS: str = '23456789TJQKA'
+    STR_SUITS: str = 'shdc'
     INT_RANKS: range = range(13)
     PRIMES: list[int] = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41]
 

--- a/treys/deck.py
+++ b/treys/deck.py
@@ -36,7 +36,7 @@ class Deck:
 
         # create the standard 52 card deck
         for rank in Card.STR_RANKS:
-            for suit, _ in Card.CHAR_SUIT_TO_INT_SUIT.items():
+            for suit in Card.STR_SUITS:
                 Deck._FULL_DECK.append(Card.new(rank + suit))
 
         return list(Deck._FULL_DECK)


### PR DESCRIPTION
The latest update included unicode support to `Card.new` which also introduced a bug where the deck was always created with 104 cards instead of 52, because every card was added twice thanks to "duplicate" suit declaration in `Card.CHAR_SUIT_TO_INT_SUIT`. 

This was fixed by adding an explicit `STR_SUITS` and using those while creating the default deck.